### PR TITLE
Fix download link and change it to version 7

### DIFF
--- a/init/70_get_the_app.sh
+++ b/init/70_get_the_app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ ! -f "/config/www/pydio/index.php" ]; then
-curl -o /tmp/install.zip  -L https://sourceforge.net/projects/ajaxplorer/files/pydio/stable-channel/6.4.2/pydio-core-6.4.2.zip/download
+curl -o /tmp/install.zip  -L https://download.pydio.com/pub/core/archives/pydio-core-7.0.2.zip 
 cd /tmp || exit
 unzip install.zip
 mv pydio-*/data/* /data/


### PR DESCRIPTION
Hi ! The download in the script was not functionning, so I changed it to the last release of pydio, the major release 7. 

It has been tested and it works on my computer.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


