### PR TITLE
bump to pydio8 as default install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
-ENV PYDIO_VER="7.0.4"
+ENV PYDIO_VER="8.0.0"
 
 # add repositories
 RUN \

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For email settings edit the file /config/ssmtp.conf and restart the container.
 
 ## Versions
 
++ **17.05.17:** Make default install pydio 8.
 + **03.05.17:** Use repo pinning to better solve dependencies, use repo version of php7-imagick.
 + **28.02.17:** Modify sed for data path.
 + **18.02.17:** Rebase to alpine linux 3.5.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ fixes #16 in a roundabout way by recommending update to pydio8 through the webui
+ bumping default install to pydio8