### PR TITLE
adds http support for use as http backend behind reverse proxy

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -2,7 +2,8 @@ server {
         server_name _;
         root /config/www/pydio;
         index index.php;
-        listen 443 ssl;
+        listen 80;
+        listen 443 default_server ssl;
         keepalive_requests    10;
         keepalive_timeout     60 60;
         access_log /config/log/pydio/access_pydio6_log;


### PR DESCRIPTION
Dockerfile exposes port 80 as if http connections would be supported, but default site-conf does not listen on port 80.  This is problematic for anyone who wants to use this container as an http backend behind an https reverse proxy.  Addresses unanswered requests for support at https://forum.linuxserver.io/thread-206.html

